### PR TITLE
Update footer copyright year to 2026

### DIFF
--- a/_includes/layouts/base-en.njk
+++ b/_includes/layouts/base-en.njk
@@ -140,7 +140,7 @@
     </main>
 
     <footer>
-      <p>&copy; 2025 {{ metadata.author.name }}</p>
+      <p>&copy; 2026 {{ metadata.author.name }}</p>
       <p>Codes on <a href="https://github.com/mufidu/mufidu.com" target="_blank" rel="noopener noreferrer">GitHub</a>.</p>
     </footer>
 

--- a/_includes/layouts/base-id.njk
+++ b/_includes/layouts/base-id.njk
@@ -137,7 +137,7 @@
     </main>
 
     <footer>
-      <p>&copy; 2025 {{ metadata.author.name }}</p>
+      <p>&copy; 2026 {{ metadata.author.name }}</p>
       <p>Codes on <a href="https://github.com/mufidu/mufidu.com" target="_blank" rel="noopener noreferrer">GitHub</a>.</p>
     </footer>
 


### PR DESCRIPTION
### Motivation
- Keep the site footer up to date by changing the displayed copyright year from 2025 to 2026 in both language base layouts.

### Description
- Replace `&copy; 2025` with `&copy; 2026` in `_includes/layouts/base-en.njk`.
- Replace `&copy; 2025` with `&copy; 2026` in `_includes/layouts/base-id.njk`.

### Testing
- Located occurrences of `2025` using `rg -n "2025" .` and confirmed the matches were in the two layout templates.
- Verified the updated lines with `nl -ba _includes/layouts/base-id.njk | sed -n '132,146p'` and `nl -ba _includes/layouts/base-en.njk | sed -n '138,148p'`, which show `&copy; 2026`.
- Inspected the diff output for the two files to confirm only the year literals were changed and no other content was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db34ecd9a88320bbb1da5df36979b4)